### PR TITLE
GH-5 - Fix modifying concepts that are not always applicable.

### DIFF
--- a/src/main/resources/META-INF/jqassistant-rules/dashboard.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/dashboard.xml
@@ -26,6 +26,9 @@
             ORDER BY
               NumberOfDuplicates desc
         ]]></cypher>
+        <verify>
+            <rowCount min="0"/>
+        </verify>
     </concept>
 
     <concept id="jqassistant-dashboard:GitDuplicateAuthorsByEmail">
@@ -50,6 +53,9 @@
             ORDER BY
               NumberOfDuplicates desc
         ]]></cypher>
+        <verify>
+            <rowCount min="0"/>
+        </verify>
     </concept>
 
     <concept id="jqassistant-dashboard:GitMergeCommit">
@@ -67,7 +73,7 @@
               count(c) as MergeCommits
         ]]></cypher>
         <verify>
-            <aggregation />
+            <aggregation min="0" />
         </verify>
     </concept>
 


### PR DESCRIPTION
Both concepts cleaning up authors and labelling merge commits are not always applicable and must also be valid with a minimum of 0 rows. This fixes #5.